### PR TITLE
feat(issue-34): Generar y Exponer Especificaciones OpenAPI y actualizar Dockerfiles a bullseye

### DIFF
--- a/src/api-gateway/Dockerfile
+++ b/src/api-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM python:3.9-slim-bullseye
 
 WORKDIR /app
 

--- a/src/servicio-asignaturas/Dockerfile
+++ b/src/servicio-asignaturas/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM python:3.9-slim-bullseye
 
 WORKDIR /app
 

--- a/src/servicio-suscripciones/Dockerfile
+++ b/src/servicio-suscripciones/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM python:3.9-slim-bullseye
 
 WORKDIR /app
 

--- a/src/servicio-usuarios/Dockerfile
+++ b/src/servicio-usuarios/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM python:3.9-slim-bullseye
 
 WORKDIR /app
 


### PR DESCRIPTION
Resuelve el issue #34.

Se verificó que los microservicios de FastAPI generan y exponen automáticamente sus especificaciones OpenAPI en /openapi.json, accesibles dentro de la red Docker.

Además, se actualizaron las imágenes base de los Dockerfiles de 'python:3.9-slim-buster' a 'python:3.9-slim-bullseye' para resolver problemas con los repositorios de apt-get y asegurar la consistencia.